### PR TITLE
Configure aurelia before loading features

### DIFF
--- a/aurelia/__if_not_plugin/src/main.ext
+++ b/aurelia/__if_not_plugin/src/main.ext
@@ -8,8 +8,8 @@ import { Aurelia } from 'aurelia-framework';
 
 // @endif
 export function configure(aurelia/* @if typescript */: Aurelia/* @endif */)/* @if typescript */: void/* @endif */ {
-  aurelia.use.feature('resources');
   aurelia.use.standardConfiguration();
+  aurelia.use.feature('resources');
   if (process.env.NODE_ENV === 'production') {
     aurelia.use.developmentLogging('warn');
   } else {

--- a/aurelia/__if_plugin/dev-app/main.ext
+++ b/aurelia/__if_plugin/dev-app/main.ext
@@ -9,8 +9,8 @@ import { Aurelia } from 'aurelia-framework';
 // @endif
 export function configure(aurelia/* @if typescript */: Aurelia/* @endif */)/* @if typescript */: void/* @endif */ {
   // Load local plugin from ../src
-  aurelia.use.feature('../src');
   aurelia.use.standardConfiguration();
+  aurelia.use.feature('../src');
   aurelia.use.developmentLogging('info');
   aurelia.use.plugin('aurelia-testing');
 


### PR DESCRIPTION
Fixes an edge case where a plugin uses a router provided by the main app, causing an initialization issue.